### PR TITLE
Fixed Behavior

### DIFF
--- a/src/hoverintent.js
+++ b/src/hoverintent.js
@@ -60,7 +60,7 @@
         };
 
         var dispatch = function(e, event, over) {
-            var tracker = function() {
+            var tracker = function(e) {
                 track(e);
             };
 


### PR DESCRIPTION
tracker did not receive a input param, therefore "e" was always pulled from the scope of the dispatch function, remaining static for the whole duration, essentially disabling the intended hoverintent behavior and reducing it to a delay hover check. ;)
