### PR TITLE
Limit published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,10 @@
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "uglify-js": "^2.6.1"
-  }
+  },
+  "files": [
+    "dist",
+    "ender.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
The published npm package doesn't need any site-related files like site.css and index.html.

I'm not familiar with ender, so correct me if it's not needed.